### PR TITLE
Move socket.io inside apply method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,17 @@
-var io = require('socket.io')(8196)
-
-const socket = {
-  init (data) {
-    data.html += '<script src="http://localhost:8196/socket.io/socket.io.js"></script>'
-    data.html += '<script>var socket = io.connect("http://localhost:8196");socket.on("reload", function(){window.location.reload()});</script>'
-  },
-  reload () {
-    io.emit('reload')
-  }
-}
-
 class HtmlWebpackReloadPlugin {
   apply (compiler) {
+    var io = require('socket.io')(8196)
+
+    const socket = {
+      init (data) {
+        data.html += '<script src="http://localhost:8196/socket.io/socket.io.js"></script>'
+        data.html += '<script>var socket = io.connect("http://localhost:8196");socket.on("reload", function(){window.location.reload()});</script>'
+      },
+      reload () {
+        io.emit('reload')
+      }
+    }
+    
     compiler.hooks.compilation.tap('HtmlWebpackReload', function (compilation) {
       compilation.hooks.htmlWebpackPluginBeforeHtmlProcessing.tapAsync('HtmlWebpackReload', function (data, callback) {
         socket.init(data)


### PR DESCRIPTION
Socket creation was moved inside apply method, to allow a correctly process exit from webpack compiler.